### PR TITLE
Updated malformed urls in `Instruction Tuning`

### DIFF
--- a/1_instruction_tuning/README.md
+++ b/1_instruction_tuning/README.md
@@ -22,8 +22,8 @@ Supervised Fine-Tuning (SFT) is a critical process for adapting pre-trained lang
 ## References
 
 - [Transformers documentation on chat templates](https://huggingface.co/docs/transformers/main/en/chat_templating)
-- [Script for Supervised Fine-Tuning in TRL]([./scripts/supervised_finetuning.py](https://github.com/huggingface/trl/blob/main/examples/scripts/sft.py))
-- [`SFTTrainer` in TRL]([./chat_templates.md](https://huggingface.co/docs/trl/main/en/sft_trainer))
+- [Script for Supervised Fine-Tuning in TRL](https://github.com/huggingface/trl/blob/main/examples/scripts/sft.py)
+- [`SFTTrainer` in TRL](https://huggingface.co/docs/trl/main/en/sft_trainer)
 - [Direct Preference Optimization Paper](https://arxiv.org/abs/2305.18290)
 - [Supervised Fine-Tuning with TRL](https://huggingface.co/docs/trl/main/en/tutorials/supervised_finetuning)
 - [How to fine-tune Google Gemma with ChatML and Hugging Face TRL](https://www.philschmid.de/fine-tune-google-gemma)


### PR DESCRIPTION
# December 2024 Student Submission

## Module Completed
- [x] Module 1: Instruction Tuning

## Changes Made

Small update in some malformed URLs in [Instruction Tuning](https://github.com/sergiopaniego/smol-course/tree/main/1_instruction_tuning).

The

````
 - [Supervised Fine-Tuning with TRL](https://huggingface.co/docs/trl/main/en/tutorials/supervised_finetuning) 
````

is still giving 404 but I'm not sure about the correct link. 

@burtenshaw 

## Notebooks Added/Modified
List any notebooks you've added or modified:
- [ ] Added new example in `module_name/students/my_example.ipynb`
- [ ] Modified existing notebook with additional examples
- [ ] Added documentation or comments

## Checklist

- [ ] I have read the module materials
- [ ] My code runs without errors
- [ ] I have pushed models and datasets to the huggingface hub
- [ ] My PR is based on the `december_2024` branch

## Questions or Discussion Points
Add any questions you have or points you'd like to discuss:
1. 
2. 

## Additional Notes
Any other information that might be helpful for reviewers:

