### PR TITLE
bugfix/Remove split from load_dataset

### DIFF
--- a/2_preference_alignment/notebooks/orpo_finetuning_example.ipynb
+++ b/2_preference_alignment/notebooks/orpo_finetuning_example.ipynb
@@ -87,7 +87,7 @@
     "# Load dataset\n",
     "\n",
     "# TODO: 🦁🐕 change the dataset to one of your choosing\n",
-    "dataset = load_dataset(path=\"trl-lib/ultrafeedback_binarized\", split=\"train\")"
+    "dataset = load_dataset(path=\"trl-lib/ultrafeedback_binarized\")"
    ]
   },
   {


### PR DESCRIPTION
Small fix to solve issue when running ORPOTrainer. Definition specifies train and eval splits but only train dataset is being downloaded