### PR TITLE
Fix : Small fixes  in DPO trainer args in DPO notebook

### DIFF
--- a/2_preference_alignment/notebooks/dpo_finetuning_example.ipynb
+++ b/2_preference_alignment/notebooks/dpo_finetuning_example.ipynb
@@ -296,11 +296,11 @@
     "    processing_class=tokenizer,\n",
     "    # DPO-specific temperature parameter that controls the strength of the preference model\n",
     "    # Lower values (like 0.1) make the model more conservative in following preferences\n",
-    "    beta=0.1,\n",
+    "    #beta=0.1,\n",
     "    # Maximum length of the input prompt in tokens\n",
-    "    max_prompt_length=1024,\n",
+    "    #max_prompt_length=1024,\n",
     "    # Maximum combined length of prompt + response in tokens\n",
-    "    max_length=1536,\n",
+    "    #max_length=1536,\n",
     ")"
    ]
   },
@@ -357,7 +357,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.10"
+   "version": "3.12.7"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {


### PR DESCRIPTION

## Changes Made
Small fixes in the parameters present in the DPO trainer. While training the SmolLM instruct model on the ```"trl-lib/ultrafeedback_binarized``` dataset , using the following arguments which were present
```
beta=0.1,
# Maximum length of the input prompt in tokens
max_prompt_length=1024,
# Maximum combined length of prompt + response in tokens
max_length=1536
```

resulted in unexpected keyword argument errors.

Felt it would be better if the user can modify it based on their need and dataset used , rather than these arguments present by default and resulting in errors.
