### PR TITLE
Update README.md

### DIFF
--- a/8_agents/README.md
+++ b/8_agents/README.md
@@ -4,7 +4,7 @@ AI Agents are autonomous systems that can understand user requests, break them d
 
 ## Module Overview
 
-Building effective agents requires understanding three key components. First, retrieval capabilities allow agents to access and use relevant information from various sources. Second, function calling enables agents to take concrete actions in their environment. Finally, domain-specific knowledge and tooling equips agents for specialized tasks like code manipulation.
+Building effective agents requires understanding three key components. First, retrieval capabilities allow agents to access and use relevant information from various sources. Second, function calling enables agents to take concrete actions in their environment. Finally, domain-specific knowledge and tooling equip agents for specialized tasks like code manipulation.
 
 ## Contents
 


### PR DESCRIPTION
Fix plural subject–verb agreement for “knowledge and tooling”

- **Issue**: The phrase “domain-specific knowledge and tooling” represents a plural subject, but the verb form used (“equips”) is singular.  

- **Fix**: Change “equips” to “equip” to correctly reflect the plural subject.  

- When two items are joined by “and”—in this case, “knowledge” and “tooling”—they form a plural subject.  

- Using “equip” (plural) maintains proper subject–verb agreement.