### PR TITLE
`Agents` module nits

### DIFF
--- a/8_agents/README.md
+++ b/8_agents/README.md
@@ -28,7 +28,7 @@ Custom function agents extend basic AI capabilities through specialized function
 
 ## Resources
 
-- [SmoLAgents Documentation](https://huggingface.co/docs/smolagents) - Official docs for the SmoLAgents library
+- [smolagents Documentation](https://huggingface.co/docs/smolagents) - Official docs for the smolagents library
 - [Building Effective Agents](https://www.anthropic.com/research/building-effective-agents) - Research paper on agent architectures
 - [Agent Guidelines](https://huggingface.co/docs/smolagents/tutorials/building_good_agents) - Best practices for building reliable agents
 - [LangChain Agents](https://python.langchain.com/docs/how_to/#agents) - Additional examples of agent implementations

--- a/8_agents/README.md
+++ b/8_agents/README.md
@@ -24,7 +24,7 @@ Custom function agents extend basic AI capabilities through specialized function
 
 | Title | Description | Exercise | Link | Colab |
 |-------|-------------|----------|------|-------|
-| Building a Research Agent | Create an agent that can perform research tasks using retrieval and custom functions | 🐢 Build a simple RAG agent <br> 🐕 Add custom search functions <br> 🦁 Create a full research assistant | [Notebook](./notebooks/agents.ipynb) | <a target="_blank" href="https://colab.research.google.com/github/huggingface/smol-course/blob/main/8_agents/notebooks/building_research_agent.ipynb"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a> |
+| Building a Research Agent | Create an agent that can perform research tasks using retrieval and custom functions | 🐢 Build a simple RAG agent <br> 🐕 Add custom search functions <br> 🦁 Create a full research assistant | [Notebook](./notebooks/agents.ipynb) | <a target="_blank" href="https://colab.research.google.com/github/huggingface/smol-course/blob/main/8_agents/notebooks/agents.ipynb"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a> |
 
 ## Resources
 

--- a/8_agents/README.md
+++ b/8_agents/README.md
@@ -31,6 +31,6 @@ Custom function agents extend basic AI capabilities through specialized function
 - [SmoLAgents Documentation](https://huggingface.co/docs/smolagents) - Official docs for the SmoLAgents library
 - [Building Effective Agents](https://www.anthropic.com/research/building-effective-agents) - Research paper on agent architectures
 - [Agent Guidelines](https://huggingface.co/docs/smolagents/tutorials/building_good_agents) - Best practices for building reliable agents
-- [LangChain Agents](https://python.langchain.com/docs/modules/agents/) - Additional examples of agent implementations
+- [LangChain Agents](https://python.langchain.com/docs/how_to/#agents) - Additional examples of agent implementations
 - [Function Calling Guide](https://platform.openai.com/docs/guides/function-calling) - Understanding function calling in LLMs
 - [RAG Best Practices](https://www.pinecone.io/learn/retrieval-augmented-generation/) - Guide to implementing effective RAG

--- a/8_agents/code_agents.md
+++ b/8_agents/code_agents.md
@@ -57,12 +57,12 @@ agent.run("Can you give me a nice one-day trip around Paris with a few locations
 
 ```
 
-These examples are just the beginning of what you can do with code agents. You can learn more about how to build code agents in the [SmoLAgents documentation](https://huggingface.co/docs/smolagents).
+These examples are just the beginning of what you can do with code agents. You can learn more about how to build code agents in the [smolagents documentation](https://huggingface.co/docs/smolagents).
 
-SmoLAgents provides a lightweight framework for building code agents, with a core implementation of approximately 1,000 lines of code. The framework specializes in agents that write and execute Python code snippets, offering sandboxed execution for security. It supports both open-source and proprietary language models, making it adaptable to various development environments.
+smolagents provides a lightweight framework for building code agents, with a core implementation of approximately 1,000 lines of code. The framework specializes in agents that write and execute Python code snippets, offering sandboxed execution for security. It supports both open-source and proprietary language models, making it adaptable to various development environments.
 
 ## Further Reading
 
-- [SmoLAgents Blog](https://huggingface.co/blog/smolagents) - Introduction to SmoLAgents and code interactions
-- [SmoLAgents: Building Good Agents](https://huggingface.co/docs/smolagents/tutorials/building_good_agents) - Best practices for reliable agents
+- [smolagents Blog](https://huggingface.co/blog/smolagents) - Introduction to smolagents and code interactions
+- [smolagents: Building Good Agents](https://huggingface.co/docs/smolagents/tutorials/building_good_agents) - Best practices for reliable agents
 - [Building Effective Agents - Anthropic](https://www.anthropic.com/research/building-effective-agents) - Agent design principles

--- a/8_agents/custom_functions.md
+++ b/8_agents/custom_functions.md
@@ -65,5 +65,5 @@ def process_search():
 
 ## Further Reading
 
-- [SmoLAgents Blog](https://huggingface.co/blog/smolagents) - Learn about the latest advancements in AI agents and how they can be applied to custom function agents.
+- [smolagents Blog](https://huggingface.co/blog/smolagents) - Learn about the latest advancements in AI agents and how they can be applied to custom function agents.
 - [Building Good Agents](https://huggingface.co/docs/smolagents/tutorials/building_good_agents) - A comprehensive guide on best practices for developing reliable and effective custom function agents.

--- a/8_agents/notebooks/agents.ipynb
+++ b/8_agents/notebooks/agents.ipynb
@@ -85,10 +85,10 @@
             "outputs": [],
             "source": [
                 "from smolagents import CodeAgent, tool\n",
-                "from typing import Union, List\n",
+                "from typing import Union\n",
                 "\n",
                 "@tool\n",
-                "def calculate(operation: str, numbers: List[float]) -> float:\n",
+                "def calculate(operation: str, numbers: object) -> float:\n",
                 "    \"\"\"Performs basic mathematical operations on a list of numbers.\n",
                 "    \n",
                 "    Args:\n",


### PR DESCRIPTION
## Module Completed
- [x] Module 8: Agents

## Changes Made

Nice upgrade with the new Agents module 😄!  
I was reading it and found some small nits that I addressed in this PR:

* The LangChain URL for agents was not working.
* I've updated `SmoLAgents` to `smolagents`.
* The Colab link was [not working](https://python.langchain.com/docs/modules/agents/).
* When running the notebook, there was an update in the library so if you use `def calculate(operation: str, numbers: List[float]) -> float:` it doesn't work. I've updated it to use `object` instead of `List`. It generates the following error when using `List`:
```
Exception: Input 'numbers': type 'array' is not an authorized value, should be one of ['string', 'boolean', 'integer', 'number', 'image', 'audio', 'any', 'object'].
```

## Notebooks Added/Modified

* `8_agents/notebooks/agents.ipynb`

@burtenshaw 