### PR TITLE
fix: correct CodeAgent usage in retrieval_agents.md

### DIFF
--- a/8_agents/retrieval_agents.md
+++ b/8_agents/retrieval_agents.md
@@ -9,16 +9,16 @@ Traditional RAG has key limitations - it only performs a single retrieval step a
 Let's start by building a simple agent that can search the web using DuckDuckGo. This agent will be able to answer questions by retrieving relevant information and synthesizing responses.
 
 ```python
-from smolagents import CodeAgent
-from smolagents.tools import DuckDuckGoSearch
+from smolagents import CodeAgent, DuckDuckGoSearchTool, HfApiModel
 
 # Initialize the search tool
-search_tool = DuckDuckGoSearch()
+search_tool = DuckDuckGoSearchTool()
 
-# Create an agent with memory
+# Initialize the model
+model = HfApiModel()
+
 agent = CodeAgent(
-    name="research_assistant",
-    description="I help find and synthesize information from the web",
+    model = model,
     tools=[search_tool]
 )
 


### PR DESCRIPTION
This PR fixes incorrect import statements and usage examples in the agents module tutorial. The current examples show incorrect ways of importing and using smolagents classes, which could confuse learners trying to follow the course.

- Wrong tool imports (DuckDuckGoSearch → DuckDuckGoSearchTool)
- Missing required model initialization
- Removal of unnecessary parameters (name, description) - these parameters are actually used in ManagedAgent class, not CodeAgent. The current documentation appears to have confused these two different agent types
- Proper component initialization before agent creation
- Removed misleading comment about memory - the example doesn't actually configure any memory features