### PR TITLE
Fixed minor typo in supervised_fine_tuning.md

### DIFF
--- a/1_instruction_tuning/supervised_fine_tuning.md
+++ b/1_instruction_tuning/supervised_fine_tuning.md
@@ -28,7 +28,7 @@ SFT plays a fundamental role in aligning language models with human preferences.
 
 ## Supervised Fine-Tuning With Transformer Reinforcement Learning
 
-A key software package for Supervised Fine-Tuning is Transformer Reinforcement Learning (TRL). TRL is a toolkit used to train transformer language models models using reinforcement learning (RL).
+A key software package for Supervised Fine-Tuning is Transformer Reinforcement Learning (TRL). TRL is a toolkit used to train transformer language models using reinforcement learning (RL).
 
 Built on top of the Hugging Face Transformers library, TRL allows users to directly load pretrained language models and supports most decoder and encoder-decoder architectures. The library facilitates major processes of RL used in language modelling, including supervised fine-tuning (SFT), reward modeling (RM), proximal policy optimization (PPO), and Direct Preference Optimization (DPO). We will use TRL in a number of modules throughout this repo.
 


### PR DESCRIPTION
# December 2024 Student Submission

## Module Completed
- [x] Module 1: Instruction Tuning
- [ ] Module 2: Preference Alignment
- [ ] Module 3: Parameter-efficient Fine-tuning
- [ ] Module 4: Evaluation
- [ ] Module 5: Vision-language Models
- [ ] Module 6: Synthetic Datasets
- [ ] Module 7: Inference
- [ ] Module 8: Deployment

## Changes Made
Describe what you've done in this PR:
What changes or additions did you make? - fixed a very minor typo in supervised_fine_tuning.md. The word "models" was repeated unnecessarily in one line


