### PR TITLE
fix: notebook import error

### DIFF
--- a/8_agents/notebooks/agents.ipynb
+++ b/8_agents/notebooks/agents.ipynb
@@ -146,8 +146,7 @@
             "metadata": {},
             "outputs": [],
             "source": [
-                "from smolagents import CodeAgent\n",
-                "from smolagents.tools import DuckDuckGoSearch\n",
+                "from smolagents import CodeAgent, DuckDuckGoSearchTool\n",
                 "\n",
                 "# Initialize the agent with memory\n",
                 "research_agent = CodeAgent(...)  # TODO: Define the agent\n",
@@ -178,6 +177,18 @@
             "display_name": "Python 3",
             "language": "python",
             "name": "python3"
+        },
+        "language_info": {
+            "codemirror_mode": {
+                "name": "ipython",
+                "version": 3
+            },
+            "file_extension": ".py",
+            "mimetype": "text/x-python",
+            "name": "python",
+            "nbconvert_exporter": "python",
+            "pygments_lexer": "ipython3",
+            "version": "3.12.8"
         }
     },
     "nbformat": 4,


### PR DESCRIPTION
# December 2024 Student Submission

## Module Completed
- [ ] Module 1: Instruction Tuning
- [ ] Module 2: Preference Alignment
- [ ] Module 3: Parameter-efficient Fine-tuning
- [ ] Module 4: Evaluation
- [ ] Module 5: Vision-language Models
- [ ] Module 6: Synthetic Datasets
- [ ] Module 7: Inference
- [ ] Module 8: Deployment

## Changes Made
Describe what you've done in this PR:
1. What concepts did you learn?
2. What changes or additions did you make?
3. Any challenges you faced?

## Notebooks Added/Modified
List any notebooks you've added or modified:
- [ ] Added new example in `module_name/student_examples/my_example.ipynb`
- [ ] Modified existing notebook with additional examples
- [ ] Added documentation or comments

## Checklist

- [ ] I have read the module materials
- [x] My code runs without errors
- [ ] I have pushed models and datasets to the huggingface hub
- [ ] My PR is based on the `december-2024` branch

## Questions or Discussion Points
Add any questions you have or points you'd like to discuss:

## Additional Notes

prior to fix:

```bash
---------------------------------------------------------------------------
ImportError                               Traceback (most recent call last)
Cell In[1], [line 2](vscode-notebook-cell:?execution_count=1&line=2)
      [1](vscode-notebook-cell:?execution_count=1&line=1) from smolagents import CodeAgent
----> [2](vscode-notebook-cell:?execution_count=1&line=2) from smolagents.tools import DuckDuckGoSearch
      [4](vscode-notebook-cell:?execution_count=1&line=4) # Initialize the agent with memory
      [5](vscode-notebook-cell:?execution_count=1&line=5) research_agent = CodeAgent(...)  # TODO: Define the agent

ImportError: cannot import name 'DuckDuckGoSearch' from 'smolagents.tools' (/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages/smolagents/tools.py)
```

