### PR TITLE
fix: rename tokenizer to processing_class within SFTTrainer

### DIFF
--- a/1_instruction_tuning/notebooks/sft_finetuning_example.ipynb
+++ b/1_instruction_tuning/notebooks/sft_finetuning_example.ipynb
@@ -166,7 +166,7 @@
     "    model=model,\n",
     "    args=sft_config,\n",
     "    train_dataset=ds[\"train\"],\n",
-    "    tokenizer=tokenizer,\n",
+    "    processing_class=tokenizer,\n",
     "    eval_dataset=ds[\"test\"],\n",
     ")\n",
     "\n",


### PR DESCRIPTION
See [Rename trainer arg tokenizer to processing_class] in https://github.com/huggingface/trl/releases/tag/v0.12.0.