### PR TITLE
Fix : Move max_seq_length, packing, and dataset_kwargs to SFTConfig from SFTTrainer in finetune_sft_peft notebook

### DIFF
--- a/3_parameter_efficient_finetuning/notebooks/finetune_sft_peft.ipynb
+++ b/3_parameter_efficient_finetuning/notebooks/finetune_sft_peft.ipynb
@@ -224,6 +224,7 @@
    "outputs": [],
    "source": [
     "# Training configuration\n",
+    "max_seq_length = 1512  # max sequence length for model and packing of the dataset\n",
     "# Hyperparameters based on QLoRA paper recommendations\n",
     "args = SFTConfig(\n",
     "    # Output settings\n",
@@ -250,6 +251,12 @@
     "    # Integration settings\n",
     "    push_to_hub=False,  # Don't push to HuggingFace Hub\n",
     "    report_to=\"none\",  # Disable external logging\n",
+    "    max_seq_length=max_seq_length, # max sequence length for model and packing of the dataset\n",
+    "    packing=True, # Enable input packing for efficiency\n",
+    "    dataset_kwargs={\n",
+    "        \"add_special_tokens\": False,  # Special tokens handled by template\n",
+    "        \"append_concat_token\": False,  # No additional separator needed\n",
+    "    },\n",
     ")"
    ]
   },
@@ -270,21 +277,13 @@
    },
    "outputs": [],
    "source": [
-    "max_seq_length = 1512  # max sequence length for model and packing of the dataset\n",
-    "\n",
     "# Create SFTTrainer with LoRA configuration\n",
     "trainer = SFTTrainer(\n",
     "    model=model,\n",
     "    args=args,\n",
     "    train_dataset=dataset[\"train\"],\n",
     "    peft_config=peft_config,  # LoRA configuration\n",
-    "    max_seq_length=max_seq_length,  # Maximum sequence length\n",
     "    tokenizer=tokenizer,\n",
-    "    packing=True,  # Enable input packing for efficiency\n",
-    "    dataset_kwargs={\n",
-    "        \"add_special_tokens\": False,  # Special tokens handled by template\n",
-    "        \"append_concat_token\": False,  # No additional separator needed\n",
-    "    },\n",
     ")"
    ]
   },


### PR DESCRIPTION
## Changes Made
This PR moves SFTTrainer arguments (`max_seq_length`, `packing`, and `dataset_kwargs`) to SFTConfig to match updated TRL implementation (reference: [https://github.com/huggingface/trl/blob/main/trl/trainer/sft_config.py](https://github.com/huggingface/trl/blob/main/trl/trainer/sft_config.py)) in [finetune_sft_peft.ipynb](https://github.com/huggingface/smol-course/blob/main/3_parameter_efficient_finetuning/notebooks/finetune_sft_peft.ipynb) 

Related: [https://github.com/unslothai/unsloth/issues/1264#issuecomment-2466773074](https://github.com/unslothai/unsloth/issues/1264#issuecomment-2466773074)

## Notebooks Modified:
- [finetune_sft_peft.ipynb](https://github.com/huggingface/smol-course/blob/main/3_parameter_efficient_finetuning/notebooks/finetune_sft_peft.ipynb) 

---
Note: This PR does NOT address the `tokenizer` to `processing_class` change, as that's already covered in [PR #214](https://github.com/huggingface/smol-course/pull/214). These changes complement each other but are independent. In order to run the notebook, it is advised to incorporate both the changes.