### PR TITLE
Fix peft example

### DIFF
--- a/units/en/unit1/3a.md
+++ b/units/en/unit1/3a.md
@@ -55,7 +55,7 @@ PEFT methods can be combined with TRL (Transformers Reinforcement Learning) for 
 
 ```python
 from peft import LoraConfig
-from transformers import AutoModelForCausalLM
+from trl import SFTTrainer
 
 # Load model with PEFT config
 lora_config = LoraConfig(
@@ -66,11 +66,9 @@ lora_config = LoraConfig(
     task_type="CAUSAL_LM"
 )
 
-# Load model on specific device
-model = AutoModelForCausalLM.from_pretrained(
-    "your-model-name",
-    load_in_8bit=True,  # Optional: use 8-bit precision
-    device_map="auto",
+trainer = SFTTrainer(
+    model="your-model-name",
+    train_dataset=dataset["train"]
     peft_config=lora_config
 )
 ```

--- a/units/en/unit1/3a.md
+++ b/units/en/unit1/3a.md
@@ -73,8 +73,6 @@ trainer = SFTTrainer(
 )
 ```
 
-Above, we used `device_map="auto"` to automatically assign the model to the correct device. You can also manually assign the model to a specific device using `device_map={"": device_index}`. You could also scale training across multiple GPUs while keeping memory usage efficient.
-
 ## Basic Merging Implementation
 
 After training a LoRA adapter, you can merge the adapter weights back into the base model. Here's how to do it:

--- a/v1/3_parameter_efficient_finetuning/lora_adapters.md
+++ b/v1/3_parameter_efficient_finetuning/lora_adapters.md
@@ -47,7 +47,7 @@ PEFT methods can be combined with TRL (Transformers Reinforcement Learning) for 
 
 ```python
 from peft import LoraConfig
-from transformers import AutoModelForCausalLM
+from trl import SFTTrainer
 
 # Load model with PEFT config
 lora_config = LoraConfig(
@@ -58,16 +58,12 @@ lora_config = LoraConfig(
     task_type="CAUSAL_LM"
 )
 
-# Load model on specific device
-model = AutoModelForCausalLM.from_pretrained(
-    "your-model-name",
-    load_in_8bit=True,  # Optional: use 8-bit precision
-    device_map="auto",
+trainer = SFTTrainer(
+    model="your-model-name",
+    train_dataset=dataset["train"]
     peft_config=lora_config
 )
 ```
-
-Above, we used `device_map="auto"` to automatically assign the model to the correct device. You can also manually assign the model to a specific device using `device_map={"": device_index}`. You could also scale training across multiple GPUs while keeping memory usage efficient.
 
 ## Basic Merging Implementation
 

--- a/v1/es/3_parameter_efficient_finetuning/lora_adapters.md
+++ b/v1/es/3_parameter_efficient_finetuning/lora_adapters.md
@@ -47,7 +47,7 @@ Los métodos PEFT pueden combinarse con TRL (Transformers Reinforcement Learning
 
 ```python
 from peft import LoraConfig
-from transformers import AutoModelForCausalLM
+from trl import SFTTrainer
 
 # Carga el modelo con configuración PEFT
 lora_config = LoraConfig(
@@ -58,16 +58,12 @@ lora_config = LoraConfig(
     task_type="CAUSAL_LM"
 )
 
-# Carga el modelo en un dispositivo específico
-model = AutoModelForCausalLM.from_pretrained(
-    "your-model-name",
-    load_in_8bit=True,  # Opcional: usa la precisión de 8 bits
-    device_map="auto",
+trainer = SFTTrainer(
+    model="your-model-name",
+    train_dataset=dataset["train"]
     peft_config=lora_config
 )
 ```
-
-Aquí, usamos `device_map="auto"` para asignar automáticamente el modelo al dispositivo correcto. También puedes asignar manualmente el modelo a un dispositivo específico usando `device_map={"": device_index}`. Además, podrías escalar el entrenamiento en múltiples GPUs mientras mantienes un uso eficiente de memoria.
 
 ## Implementación básica de fusión
 

--- a/v1/ja/3_parameter_efficient_finetuning/lora_adapters.md
+++ b/v1/ja/3_parameter_efficient_finetuning/lora_adapters.md
@@ -47,7 +47,7 @@ PEFTメソッドは、TRL（Transformers Reinforcement Learning）と組み合�
 
 ```python
 from peft import LoraConfig
-from transformers import AutoModelForCausalLM
+from trl import SFTTrainer
 
 # PEFT設定でモデルを読み込む
 lora_config = LoraConfig(
@@ -58,16 +58,12 @@ lora_config = LoraConfig(
     task_type="CAUSAL_LM"
 )
 
-# 特定のデバイスにモデルを読み込む
-model = AutoModelForCausalLM.from_pretrained(
-    "your-model-name",
-    load_in_8bit=True,  # オプション: 8ビット精度を使用
-    device_map="auto",
+trainer = SFTTrainer(
+    model="your-model-name",
+    train_dataset=dataset["train"]
     peft_config=lora_config
 )
 ```
-
-上記では、`device_map="auto"`を使用してモデルを自動的に適切なデバイスに割り当てました。また、`device_map={"": device_index}`を使用してモデルを特定のデバイスに手動で割り当てることもできます。メモリ使用量を効率的に保ちながら、複数のGPUにトレーニングをスケールすることもできます。
 
 ## 基本的な統合実装
 

--- a/v1/ko/3_parameter_efficient_finetuning/lora_adapters.md
+++ b/v1/ko/3_parameter_efficient_finetuning/lora_adapters.md
@@ -47,7 +47,7 @@ PEFT 방법을 구현할 때는 LoRA의 랭크를 4~8 정도의 작은 값으로
 
 ```python
 from peft import LoraConfig
-from transformers import AutoModelForCausalLM
+from trl import SFTTrainer
 
 # PEFT configuration 설정
 lora_config = LoraConfig(
@@ -58,16 +58,12 @@ lora_config = LoraConfig(
     task_type="CAUSAL_LM"
 )
 
-# 특정 디바이스에서 모델 불러오기
-model = AutoModelForCausalLM.from_pretrained(
-    "your-model-name",
-    load_in_8bit=True,  # 선택 사항: 8비트 정밀도 사용
-    device_map="auto",
+trainer = SFTTrainer(
+    model="your-model-name",
+    train_dataset=dataset["train"]
     peft_config=lora_config
 )
 ```
-
-위 코드에서 `device_map="auto"`를 사용해 모델을 적절한 디바이스에 자동으로 할당했습니다. `device_map={"": device_index}`를 써서 모델을 특정 디바이스에 직접 할당할 수도 있습니다. 또한, 메모리 사용량을 효율적으로 유지하면서 여러 GPU에 걸쳐 학습을 확장할 수도 있습니다.
 
 ## 기본적인 병합 구현
 

--- a/v1/pt-br/3_parameter_efficient_finetuning/lora_adapters.md
+++ b/v1/pt-br/3_parameter_efficient_finetuning/lora_adapters.md
@@ -47,7 +47,7 @@ Os métodos PEFT podem ser combinados com TRL (Reinforcement Learning com Transf
 
 ```python
 from peft import LoraConfig
-from transformers import AutoModelForCausalLM
+from trl import SFTTrainer
 
 # Load model with PEFT config
 lora_config = LoraConfig(
@@ -58,16 +58,12 @@ lora_config = LoraConfig(
     task_type="CAUSAL_LM"
 )
 
-# Load model on specific device
-model = AutoModelForCausalLM.from_pretrained(
-    "your-model-name",
-    load_in_8bit=True,  # Optional: use 8-bit precision
-    device_map="auto",
+trainer = SFTTrainer(
+    model="your-model-name",
+    train_dataset=dataset["train"]
     peft_config=lora_config
 )
 ```
-
-No exemplo acima, usamos `device_map="auto"` para atribuir automaticamente o modelo ao dispositivo correto. Você também pode atribuir manualmente o modelo a um dispositivo específico usando `device_map={"": device_index}`. Também é possível escalar o treinamento em várias GPUs enquanto mantém o uso de memória eficiente.
 
 ## Implementação Básica de Mesclagem
 

--- a/v1/vi/3_parameter_efficient_finetuning/lora_adapters.md
+++ b/v1/vi/3_parameter_efficient_finetuning/lora_adapters.md
@@ -47,7 +47,7 @@ Các phương pháp PEFT có thể được kết hợp với thư viện TRL đ
 
 ```python
 from peft import LoraConfig
-from transformers import AutoModelForCausalLM
+from trl import SFTTrainer
 
 # Tải mô hình với cấu hình PEFT
 lora_config = LoraConfig(
@@ -58,16 +58,12 @@ lora_config = LoraConfig(
     task_type="CAUSAL_LM"
 )
 
-# Tải mô hình trên thiết bị cụ thể
-model = AutoModelForCausalLM.from_pretrained(
-    "your-model-name",
-    load_in_8bit=True,  # Tùy chọn: sử dụng độ chính xác 8-bit
-    device_map="auto",
+trainer = SFTTrainer(
+    model="your-model-name",
+    train_dataset=dataset["train"]
     peft_config=lora_config
 )
 ```
-
-Ở trên, chúng ta đã sử dụng `device_map="auto"` để tự động gán mô hình cho thiết bị phù hợp. Bạn cũng có thể gán thủ công mô hình cho một thiết bị cụ thể bằng cách sử dụng `device_map={"": device_index}`. Bạn cũng có thể mở rộng việc huấn luyện trên nhiều GPU trong khi vẫn giữ việc sử dụng bộ nhớ hiệu quả.
 
 ## Triển khai gộp cơ bản
 


### PR DESCRIPTION
`AutoModelForCausalLM.from_pretrained` doesn't take `peft_config` as input. I guess you wanted to use `SFTTrainer`?