### PR TITLE
Change example dataset from SmolTalk2

### DIFF
--- a/units/en/unit1/4.md
+++ b/units/en/unit1/4.md
@@ -1067,7 +1067,7 @@ print("=== PREPARING DATASET ===\n")
 
 # Option 1: Use SmolTalk2 (recommended for beginners)
 dataset = load_dataset("HuggingFaceTB/smoltalk2", "SFT")
-train_dataset = dataset["train"].select(range(1000))  # Use subset for faster training
+train_dataset = dataset["smoltalk_everyday_convs_reasoning_Qwen3_32B_think"].select(range(1000))  # Use subset for faster training
 
 # Option 2: Use your own processed dataset from Exercise 2
 # train_dataset = gsm8k_formatted.select(range(500))
@@ -1089,7 +1089,7 @@ def format_chat_template(example):
         ]
     
     # Apply chat template
-    text = tokenizer.apply_chat_template(
+    text = instruct_tokenizer.apply_chat_template(
         messages, 
         tokenize=False,
         add_generation_prompt=False
@@ -1098,6 +1098,9 @@ def format_chat_template(example):
 
 # Apply formatting
 formatted_dataset = train_dataset.map(format_chat_template)
+formatted_dataset = formatted_dataset.remove_columns(
+    [col for col in formatted_dataset.column_names if col != "text"]
+)
 print(f"Formatted example: {formatted_dataset[0]['text'][:200]}...")
 ```
 
@@ -1203,7 +1206,7 @@ We instantiate the trainer, capture a pre-training baseline generation, launch `
 
 trainer = SFTTrainer(
     model=model,
-    train_dataset=dataset["train"],
+    train_dataset=formatted_dataset,
     args=config,
 )
 ```
@@ -1249,12 +1252,13 @@ In the previous exercises we've dived deep into using TRL's Python API for fine-
 
 We can define a command in TRL CLI to fine-tune a model. We'll be able to run it with `trl sft` command. The CLI command and Python API share the same configuration options.
 
+We preprocessed the `smoltalk_everyday_convs_reasoning_Qwen3_32B_think` subset of SmolTalk2 so that is easier to work with it when using the TRL CLI.
+
 ```bash
 # Fine-tune SmolLM3 using TRL CLI
 trl sft \
     --model_name_or_path HuggingFaceTB/SmolLM3-3B-Base \
-    --dataset_name HuggingFaceTB/smoltalk2 \
-    --dataset_config SFT \
+    --dataset_name HuggingFaceTB/smoltalk2_everyday_convs_think \
     --output_dir ./smollm3-sft-cli \
     --per_device_train_batch_size 4 \
     --gradient_accumulation_steps 2 \
@@ -1275,8 +1279,7 @@ For convenience and reproducibility, we can also create a configuration file to 
 ```yaml
 # Model and dataset
 model_name_or_path: HuggingFaceTB/SmolLM3-3B-Base
-dataset_name: HuggingFaceTB/smoltalk2
-dataset_config: SFT
+dataset_name: HuggingFaceTB/smoltalk2_everyday_convs_think
 output_dir: ./smollm3-advanced-sft
 
 # Training hyperparameters
@@ -1284,7 +1287,7 @@ per_device_train_batch_size: 2
 gradient_accumulation_steps: 4
 learning_rate: 3e-5
 num_train_epochs: 2
-max_seq_length: 4096
+max_length: 4096
 
 # Optimization
 warmup_steps: 200
@@ -1302,7 +1305,7 @@ remove_unused_columns: false
 logging_steps: 25
 eval_steps: 250
 save_steps: 500
-evaluation_strategy: steps
+eval_strategy: steps
 load_best_model_at_end: true
 metric_for_best_model: eval_loss
 

--- a/units/en/unit1/5.md
+++ b/units/en/unit1/5.md
@@ -64,7 +64,7 @@ config = SFTConfig(
 # Train
 trainer = SFTTrainer(
     model=model,
-    train_dataset=dataset["train"],
+    train_dataset=dataset["smoltalk_everyday_convs_reasoning_Qwen3_32B_think"],
     args=config,
 )
 trainer.train()
@@ -116,8 +116,7 @@ hf jobs uv run \
     --secrets HF_TOKEN \
     "https://raw.githubusercontent.com/huggingface/trl/main/trl/scripts/sft.py" \
     --model_name_or_path HuggingFaceTB/SmolLM3-3B-Base \
-    --dataset_name HuggingFaceTB/smoltalk2 \
-    --dataset_config SFT \
+    --dataset_name HuggingFaceTB/smoltalk2_everyday_convs_think \
     --learning_rate 5e-5 \
     --per_device_train_batch_size 4 \
     --max_steps 1000 \
@@ -173,8 +172,7 @@ hf jobs uv run \
   --secrets HF_TOKEN \
   "https://raw.githubusercontent.com/huggingface/trl/main/trl/scripts/sft.py" \
   --model_name_or_path HuggingFaceTB/SmolLM3-3B-Base \
-  --dataset_name HuggingFaceTB/smoltalk2 \
-  --dataset_config SFT \
+  --dataset_name HuggingFaceTB/smoltalk2_everyday_convs_think \
   --output_dir smollm3-lora-sft-jobs \
   --per_device_train_batch_size 4 \
   --learning_rate 5e-5 \


### PR DESCRIPTION
This PR changes how we handle the SmolTalk2 dataset for the SFT examples. 

We keep the original SmolTalk2 reference for code snippets where we can specify the dataset split. For cases where we don't we can't specify the split, we reference [`HuggingFaceTB/smoltalk2_everyday_convs_think`](https://huggingface.co/datasets/HuggingFaceTB/smoltalk2_everyday_convs_think).