### PR TITLE
Removed duplicate sentence

### DIFF
--- a/units/en/unit2/2.md
+++ b/units/en/unit2/2.md
@@ -111,8 +111,6 @@ DPO requires a [preference dataset](https://huggingface.co/docs/trl/en/dataset_f
 
 Although the `DPOTrainer` supports both explicit and implicit prompts, we recommend using explicit prompts. If provided with an implicit prompt dataset, the trainer will automatically extract the prompt from the `"chosen"` and `"rejected"` columns. For more information, refer to the [preference style](dataset_formats#preference) section.
 
-Although the `DPOTrainer` supports both explicit and implicit prompts, we recommend using explicit prompts. If provided with an implicit prompt dataset, the trainer will automatically extract the prompt from the `"chosen"` and `"rejected"` columns. For more information, refer to the [preference style](https://huggingface.co/docs/trl/en/dataset_formats#preference) section.
-
 | Parameter | Description | Recommendations |
 |-----------|-------------|-----------------|
 | **Beta (β)** | Controls the strength of preference optimization | **Range**: 0.1 to 0.5<br>**Lower values**: More conservative, closer to reference model<br>**Higher values**: Stronger preference alignment, risk of overfitting |


### PR DESCRIPTION
There is a duplicate sentence:
Although the DPOTrainer supports both explicit and implicit prompts, we recommend using explicit prompts. If provided with an implicit prompt dataset, the trainer will automatically extract the prompt from the "chosen" and "rejected" columns. For more information, refer to the preference style section.