### PR TITLE
unit1 ex1: taller markdown fence

### DIFF
--- a/units/en/unit1/4.md
+++ b/units/en/unit1/4.md
@@ -523,7 +523,7 @@ If we dive into the out put below, we can see that the instruct model's hybrid r
 <details>
 <summary>Output</summary>
 
-```python output
+````python output
 
 === TESTING REASONING CAPABILITIES ===
 
@@ -707,7 +707,7 @@ Starting with the dollars: 18 dollars plus 12 dollars is 30 dollars. Then the ce
 
 --------------------------------------------------
 
-```
+````
 
 </details>
 


### PR DESCRIPTION
I think the Markdown doesn't get processed entirely correctly in this file because the generated output contains triple backticks. I *think* this change resolves it. Note that the way it is now, causes the navigation in the rendered HTML to be a little screwy 🥴 👇 .

<img width="963" height="665" alt="unit1e1" src="https://github.com/user-attachments/assets/b2607605-c22d-46d6-9744-4357c19262ce" />
