### PR TITLE
lighteval tasks do not exist

### DIFF
--- a/units/en/unit2/4.md
+++ b/units/en/unit2/4.md
@@ -53,7 +53,7 @@ hf jobs uv run \
     --with "lighteval[vllm]" \
     --secrets HF_TOKEN \
     lighteval vllm "model_name=<your-username>/<your-model-name>" \
-    "lighteval|truthfulqa:mc2|0|0,lighteval|hellaswag|0|0,lighteval|arc:challenge|0|0" \
+    "lighteval|gsm8k|0|0,leaderboard|truthfulqa:mc|0|0,leaderboard|hellaswag|0|0,leaderboard|arc:challenge|0|0" \
     --push-to-hub --results-org <your-username>
 ```
 


### PR DESCRIPTION
the provided lighteval tasks do not exist, and the text mentions gsm8k which is not listed in the bash command. Amended the bash command to nearest existing lighteval tasks