### PR TITLE
FIX SFT example dataset

### DIFF
--- a/units/en/unit1/3.md
+++ b/units/en/unit1/3.md
@@ -462,7 +462,7 @@ model = AutoModelForCausalLM.from_pretrained("HuggingFaceTB/SmolLM3-3B-Base")
 tokenizer = AutoTokenizer.from_pretrained("HuggingFaceTB/SmolLM3-3B-Base")
 
 # Load SmolTalk2 dataset
-dataset = load_dataset("HuggingFaceTB/smoltalk2", "SFT")
+dataset = load_dataset("HuggingFaceTB/smoltalk2_everyday_convs_think")
 
 # Configure training with Trackio integration
 config = SFTConfig(
@@ -489,8 +489,7 @@ trainer.train()
 # Fine-tune SmolLM3 using TRL CLI with Trackio tracking
 trl sft \
     --model_name_or_path HuggingFaceTB/SmolLM3-3B-Base \
-    --dataset_name HuggingFaceTB/smoltalk2 \
-    --dataset_config SFT \
+    --dataset_name HuggingFaceTB/smoltalk2_everyday_convs_think \
     --output_dir ./smollm3-sft-model \
     --per_device_train_batch_size 4 \
     --learning_rate 5e-5 \


### PR DESCRIPTION
The current [HuggingFaceTB/smoltalk2](https://huggingface.co/datasets/HuggingFaceTB/smoltalk2) dataset structure is not valid for the provided code snippets since the expected `train` and `test` splits are not present. 

This change uses the same dataset as the example defined when using [hf jobs](https://huggingface.co/learn/smol-course/unit1/5#advanced-jobs-configuration).