### PR TITLE
Update 2.md by removing redundant '.representation'

### DIFF
--- a/units/en/unit3/2.md
+++ b/units/en/unit3/2.md
@@ -10,7 +10,7 @@ VLMs combine image-processing and text-generation components for a unified multi
 
 - **Image/Vision Encoder**: Converts images into compact numerical representations. Examples: CLIP, SigLIP.  
 - **Embedding Projector**: Aligns image features with text embeddings (often a small MLP or linear layer fine-tuned for the multimodal task).
-- **Multimodal Projector / Fusion Module**: Fuses and enhances connections between visual and textual representations. This step goes beyond alignment, enabling rich cross-modal interaction.representations.
+- **Multimodal Projector / Fusion Module**: Fuses and enhances connections between visual and textual representations. This step goes beyond alignment, enabling rich cross-modal interaction.
 - **Text Decoder**: Generates text (or other outputs) from the fused multimodal representations.
 
 Most VLMs leverage **pretrained image encoders and text decoders**, then fine-tune on paired image-text datasets for efficient training and generalization.


### PR DESCRIPTION
The Unit 3 teaching materials seemed to contain redundant word and full stop, so I omitted them manually.