### PR TITLE
[DOC] Improve clarity in Unit 1 pipeline section and example

### DIFF
--- a/units/en/unit1/2.md
+++ b/units/en/unit1/2.md
@@ -24,7 +24,7 @@ SmolLM3 uses the **ChatML (Chat Markup Language)** format, which has become a st
 
 ## Pipeline Usage: Automated Chat Processing
 
-The easiest way to use an open source large language model is to use the `pipeline` abstraction in 🤗 Transformers. It handles chat templates seamlessly, making it easy to use chat models without manual template management. So much so, you won't even need to know the chat template format.
+The easiest way to use an open source large language model is to use the `pipeline` abstraction in 🤗 Transformers. It handles chat templates for you, so you can start using chat models without manually writing special tokens. Later in this chapter, we'll still look at the underlying templates so you understand what the model is actually seeing. 
 
 ```python
 from transformers import pipeline
@@ -80,6 +80,8 @@ conversation = [
 
 # Generate first response
 response = pipe(conversation, **generation_config)
+
+# 'generated_text' now contains the full conversation, including the assistant reply
 conversation = response[0]['generated_text']
 
 # Continue the conversation


### PR DESCRIPTION
Hi team, 

I'm currently working through the course and wanted to suggest a couple of small wording improvements that could help with clarity and flow in the units/en/unit1/2.md.

These are subtle changes, but they aim to reduce potential confusion for first-time readers:

### 1. Pipeline section wording 
The current text mentions that learners won't even need to know the chat template format, but the rest of the page introduces and explains the format shortly after. This can feel slightly contradictory and confusing from a learning perspective. 

### 2. Advanced example clarification
In the advanced example, the transition from:
```
response = pipe(...)
```
to:
```
conversation = response[0]["generated_text"]
```
seems a bit abrupt, especially since `generated_text` now contains the full conversation. Adding a short comment makes this easier to follow. 

Hope this helps.